### PR TITLE
Handle failures in metrics commands gracefully

### DIFF
--- a/hooks/collect-metrics
+++ b/hooks/collect-metrics
@@ -6,7 +6,7 @@ sys.path.append('lib')
 
 import yaml
 import os
-from subprocess import check_output, check_call
+from subprocess import check_output, check_call, CalledProcessError
 
 
 def build_command(doc):
@@ -15,7 +15,13 @@ def build_command(doc):
     for metric, mdoc in metrics.items():
         cmd = mdoc.get("command")
         if cmd:
-            value = check_output(cmd, shell=True, universal_newlines=True)
+            try:
+                value = check_output(cmd, shell=True, universal_newlines=True)
+            except CalledProcessError as e:
+                check_call(['juju-log', '-lERROR',
+                            'Error collecting metric {}:\n{}'.format(
+                                metric, e.output)])
+                continue
             value = value.strip()
             if value:
                 values[metric] = value


### PR DESCRIPTION
If one metric collection command fails, it shouldn't break the hook, nor block other metrics from being collected.