### PR TITLE
Prevent fail if there is no attribute

### DIFF
--- a/hooks/collect-metrics
+++ b/hooks/collect-metrics
@@ -13,6 +13,8 @@ def build_command(doc):
     values = {}
     metrics = doc.get("metrics", {})
     for metric, mdoc in metrics.items():
+        if not mdoc:
+            continue
         cmd = mdoc.get("command")
         if cmd:
             try:


### PR DESCRIPTION
Otherwise a metrics.yaml file with

metrics:
  juju-info:

will fail because it doesn't find any value for the juju-info key